### PR TITLE
Use Go workspace for path management

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -111,23 +111,3 @@ replace github.com/json-iterator/go => github.com/json-iterator/go v0.0.0-201711
 replace golang.org/x/text => golang.org/x/text v0.4.0
 
 replace golang.org/x/crypto => golang.org/x/crypto v0.19.0
-
-replace github.com/couchbase/cbauth => ../goproj/src/github.com/couchbase/cbauth
-
-replace github.com/couchbase/go_json => ../goproj/src/github.com/couchbase/go_json
-
-replace github.com/couchbase/regulator => ../goproj/src/github.com/couchbase/regulator
-
-replace github.com/couchbase/cbftx => ../cbftx
-
-replace github.com/couchbase/hebrew => ../hebrew
-
-replace github.com/couchbase/cbgt => ../cbgt
-
-replace github.com/couchbase/cbft => ./empty
-
-replace github.com/couchbase/go-couchbase => ../goproj/src/github.com/couchbase/go-couchbase
-
-replace github.com/couchbase/gomemcached => ../goproj/src/github.com/couchbase/gomemcached
-
-replace github.com/couchbase/goutils => ../goproj/src/github.com/couchbase/goutils


### PR DESCRIPTION
This structure is creating some weird SBOMs. By using the following `go.work` file, the package naming is preserved

```
go 1.22.1

use (
    ./cbft
    ./cbftx
    ./cbgt
    ./goproj/src/github.com/couchbase/cbauth
    ./goproj/src/github.com/couchbase/go_json
    ./goproj/src/github.com/couchbase/go-couchbase
    ./goproj/src/github.com/couchbase/gomemcached
    ./goproj/src/github.com/couchbase/goutils
    ./goproj/src/github.com/couchbase/regulator
    ./hebrew
)

```

https://go.dev/doc/tutorial/workspaces